### PR TITLE
Updated background change in respective themes

### DIFF
--- a/about.html
+++ b/about.html
@@ -504,10 +504,21 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
+
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -515,6 +526,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/appointment.html
+++ b/appointment.html
@@ -412,17 +412,29 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
 
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
 }
+else {
+    updatebgLightElements(false);
+}
+
 
 // Toggle dark mode on button click
 themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/contact.html
+++ b/contact.html
@@ -430,10 +430,6 @@ label {
     color: black;
 }
 
-p.mb-4 ,p.px-4 {
-    color:white;
-}
-
 .form-floating input,
     .form-floating textarea {
         transition: all 0.3s ease;
@@ -543,17 +539,30 @@ p.mb-4 ,p.px-4 {
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
+
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
 }
+else {
+    updatebgLightElements(false);
+}
+
 
 // Toggle dark mode on button click
 themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 

--- a/css/bootstrap.min.css
+++ b/css/bootstrap.min.css
@@ -8365,10 +8365,6 @@ fieldset:disabled .btn {
     background-color: #dc3545 !important
 }
 
-.bg-light {
-    background-color: #333333 !important
-}
-
 .bg-dark {
     background-color: #1B2C51 !important
 }

--- a/feature.html
+++ b/feature.html
@@ -429,10 +429,20 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
 
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -440,6 +450,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/index.html
+++ b/index.html
@@ -638,6 +638,7 @@ font-family: Arial, sans-serif;
 transition: background-color 0.2s, color 0.2s;
 }
 
+
 body.darkmode {
 background-color: var(--background-color-dark);
 color: var(--text-color-dark);
@@ -691,10 +692,20 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
 
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -702,6 +713,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/service.html
+++ b/service.html
@@ -517,10 +517,21 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
+
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -528,6 +539,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/team.html
+++ b/team.html
@@ -472,10 +472,20 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
 
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -483,6 +493,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>

--- a/testimonial.html
+++ b/testimonial.html
@@ -369,10 +369,21 @@ display: block;
     document.addEventListener('DOMContentLoaded', () => {
 const themeSwitch = document.getElementById('theme-switch');
 const darkmode = localStorage.getItem('darkmode');
+const bgLightElements = document.querySelectorAll('.bg-light');
+
+function updatebgLightElements(isDarkMode) {
+    bgLightElements.forEach(element => {
+         element.style.backgroundColor= isDarkMode ? '#333333' : '#e0e0e0';
+    });
+}
 
 // Apply dark mode if the user has previously selected it
 if (darkmode === 'active') {
     document.body.classList.add('darkmode');
+    updatebgLightElements(true);
+}
+else {
+    updatebgLightElements(false);
 }
 
 // Toggle dark mode on button click
@@ -380,6 +391,7 @@ themeSwitch.addEventListener('click', () => {
     document.body.classList.toggle('darkmode');
     const isDarkMode = document.body.classList.contains('darkmode');
     localStorage.setItem('darkmode', isDarkMode ? 'active' : 'inactive');
+    updatebgLightElements(isDarkMode);
 });
 });
 </script>


### PR DESCRIPTION
## Updated background change in respective themes
- Previously, the background color of the cards in all the pages was set to default as '#333333' grey color
- It was not responsive to the theme selected such as dark mode or light mode, such as:
- In light mode: (not responsive)
  ![Screenshot 2025-02-17 224610](https://github.com/user-attachments/assets/ccdae350-fb5d-4b69-8f50-210b0bde9fc1)
- In dark mode: (not responsive)
  ![Screenshot 2025-02-17 224646](https://github.com/user-attachments/assets/26cde7d0-0bb7-48e0-a0c0-4db93a46be2c)
-Now ,after making changes in HTML and JavaScript, this issue has been corrected
- Now, the background color of the cards is responsive based on the theme selected such as dark mode or light mode
- In light mode (Responsive):
  ![Screenshot 2025-02-23 142422](https://github.com/user-attachments/assets/d7d1e176-a81e-4a21-a35b-2cf7466d6ff9)
- In dark mode (Responsive) :
  ![Screenshot 2025-02-23 142506](https://github.com/user-attachments/assets/2fb1e4c8-3dce-46c0-b3c3-09f6d85c7645)
- These changes have been applied across all pages of the SocialSync Website
