### PR TITLE
Overlapping Issue of Plus Icon and Read More Button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -311,6 +311,7 @@
     white-space: nowrap;
     overflow: hidden;
     transition: .5s;
+    padding-left: 12px; 
 }
 
 .service-item:hover .btn {
@@ -390,6 +391,7 @@
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     position: relative;
+    padding-left: 12px; 
 }
 
 .service-item:hover .btn {
@@ -411,13 +413,14 @@
 }
 
 .service-item .btn i {
-    position: absolute;
-    left: 12px;
+    position: relative;
+    left: 0;
     transition: left 0.3s ease-in-out;
+    margin-right: 8px; 
 }
 
 .service-item:hover .btn i {
-    left: 20px;
+    left: 8px;
 }
 
 .team-item img {


### PR DESCRIPTION
**Problem**
The plus icon (+) and Read More button were overlapping, causing a UI issue that affected readability and user experience.

**Solution**
Adjusted spacing and margins to ensure proper separation.
Modified the layout to prevent elements from overlapping on different screen sizes.
Ensured responsiveness by testing on various screen sizes.

**fixes** issue #88 
**Before & After Screenshots** (if applicable)
![image](https://github.com/user-attachments/assets/d8346614-9508-446d-8390-75a0f99ec1ea)


**Testing**
Verified the fix across multiple devices and screen resolutions.
Ensured no unintended side effects on other UI elements.
**Checklist**
 Fixes UI overlap issue
 Code adheres to existing design standards